### PR TITLE
Update changes field length in PackageVersionValidator

### DIFF
--- a/src/helpers/package.ts
+++ b/src/helpers/package.ts
@@ -78,7 +78,7 @@ export const PackageTypeObj = { ...PluginType, ...PresetType, ...ProjectType };
 export const PackageVersionValidator = z.object({
   audio: z.optional(z.string().min(8).max(256).startsWith('https://')),
   author: z.string().min(1).max(256),
-  changes: z.string().min(1).max(256),
+  changes: z.string().min(1).max(1024),
   date: z.string().datetime(),
   description: z.string().min(1).max(256),
   donate: z.optional(z.string().min(8).max(256).startsWith('https://')),


### PR DESCRIPTION
Increased the maximum length of the description field from 256 to 1024 characters.

256 is far too short for most change logs.