### PR TITLE
Clarify introduction of audio package manager specification

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -11,7 +11,7 @@ This document is licensed under a [Creative Commons 4.0](https://creativecommons
 
 ## Introduction
 
-This document describes an open specification for audio package managers. The goal is to enable interoperability between multiple audio platforms and the software installed locally on users computers.
+This document describes an open specification for audio package managers. The goal is to enable interoperability between multiple audio platforms and the software installed locally on users computers. Essentially, it's trying to do for audio plugins and presets what npm does for JavaScript or Cargo does for Rust.
 
 ![Open Audio Stack - Manager - Specification 1.0.0](https://raw.githubusercontent.com/open-audio-stack/open-audio-stack-registry/refs/heads/main/src/assets/open-audio-stack-diagram-manager.svg)
 


### PR DESCRIPTION
Expanded the introduction to clarify the purpose of the specification, comparing it to npm for JavaScript and Cargo for Rust.