### PR TITLE
Fix release workflow EBADENGINE failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

- The `v0.1.51` release run failed publishing with:
  ```
  npm error code EBADENGINE
  npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
  npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
  ```
- `.github/workflows/release.yml` pins Node to `20` via `actions/setup-node`, but then runs `npm install -g npm@latest` to force-upgrade npm. The current latest npm release now requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, which conflicts with the pinned Node 20 runtime.
- Node 20's bundled npm (`10.8.2`) is already well above what's needed for `npm ci` / `npm publish`, including provenance generation via the existing `id-token: write` permission (which only requires npm `>=9.5`). The forced-upgrade step served no purpose, so it's removed rather than chasing npm's version with Node's.

## Test plan

- [x] Reviewed no other workflow in `.github/workflows/` has the same forced-upgrade pattern.
- [x] `npm ci && npm run build` succeeds locally with Node 20's bundled npm.

Once merged, the `v0.1.51` tag will need to be re-pushed (or a new patch tag cut) pointing at a commit that includes this fix so the release job can run successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)