### PR TITLE
0.1.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-audio-stack/core",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-audio-stack/core",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "cc0-1.0",
       "dependencies": {
         "@vscode/sudo-prompt": "^9.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-audio-stack/core",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Open-source audio plugin management software",
   "type": "module",
   "main": "./build/index.js",


### PR DESCRIPTION
Version bump for release, generated by \`npm version patch\`.

main is branch-protected and rejects direct pushes, so this commit needs to go through a PR before the v0.1.52 tag can be pushed and the release workflow (fixed in #73) can run.