### PR TITLE
Fix release workflow so npm trusted publishing actually works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,11 @@ jobs:
       - name: Setup NodeJs
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- The `v0.1.52` release run built and tarball-packed the tarball successfully, then failed publishing with:
  ```
  npm error code E404
  npm error 404 Not Found - PUT https://registry.npmjs.org/@open-audio-stack%2fcore
  ```
- This repo publishes via npm's **OIDC Trusted Publishing** (`permissions.id-token: write` in `release.yml`, no `NPM_TOKEN` secret anywhere). Trusted Publishing requires **npm CLI >= 11.5.1**.
- #73 removed the `npm install -g npm@latest` step to fix a separate `EBADENGINE` crash (current npm requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, conflicting with the workflow's pinned Node 20). That step wasn't dead weight though — it existed specifically to get a new-enough npm for trusted publishing. Removing it fixed the crash but left the job with no working auth at all (Node 20's bundled npm 10.8.2 doesn't support OIDC trusted publishing, and there's no token fallback), so the registry 404s instead of accepting the publish.
- Fix: bump `node-version` from `'20'` to `'lts/*'` so the runner is always on a Node release new enough to install whatever npm version trusted publishing currently requires, and restore the `npm install -g npm@latest` step.

## Test plan

- [x] Confirmed via npm's docs that Trusted Publishing requires npm >=11.5.1, and that Node 20's bundled npm (10.8.2) predates that.
- [x] `npm ci && npm run build` succeed locally with a current npm (11.12.1).
- [ ] Actual release run (requires pushing a new tag once merged) — can't be verified until the next `npm version` + tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)