### PR TITLE
fix: create missing target directory before tar extraction

### DIFF
--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -83,6 +83,9 @@ export async function archiveExtract(filePath: string, dirPath: string) {
       }
     }
   } else if (isTarFile) {
+    // node-tar requires cwd to already exist, unlike AdmZip/7zip-min which create their
+    // own target directory.
+    dirCreate(dirPath);
     // node-tar rejects '..' path segments and relativizes absolute paths by default
     // (preservePaths is false unless explicitly opted into), so no extra check is needed here.
     return await tar.extract({

--- a/tests/helpers/file.test.ts
+++ b/tests/helpers/file.test.ts
@@ -1,7 +1,9 @@
 import os from 'os';
 import path from 'path';
+import * as tar from 'tar';
 import { expect, test } from 'vitest';
 import {
+  archiveExtract,
   dirApp,
   dirCreate,
   dirContains,
@@ -19,6 +21,7 @@ import {
   dirRename,
   fileCreate,
   fileHash,
+  fileReadString,
   isSafeArchiveEntryPath,
   // fileCreateJson,
   // fileDate,
@@ -79,6 +82,24 @@ test('Archive entry path escapes extraction directory', () => {
   const root = path.resolve('test', 'extract-root');
   expect(isSafeArchiveEntryPath(path.join('..', '..', 'etc', 'passwd'), root)).toEqual(false);
   expect(isSafeArchiveEntryPath(path.resolve('/etc/passwd'), root)).toEqual(false);
+});
+
+test('Archive extract creates missing tar target directory', async () => {
+  // Regression test for https://github.com/open-audio-stack/open-audio-stack-core/issues/85 -
+  // node-tar requires cwd to already exist, unlike AdmZip/7zip-min which create it themselves.
+  const sourceDir: string = path.join('test', 'tar-source');
+  const archivePath: string = path.join('test', 'archive.tgz');
+  const extractDir: string = path.join('test', 'nested', 'missing', 'target');
+  dirCreate(sourceDir);
+  fileCreate(path.join(sourceDir, 'plugin.vst3'), 'plugin contents');
+  await tar.create({ file: archivePath, cwd: sourceDir }, ['plugin.vst3']);
+
+  expect(dirExists(extractDir)).toEqual(false);
+  await archiveExtract(archivePath, extractDir);
+  expect(fileReadString(path.join(extractDir, 'plugin.vst3'))).toEqual('plugin contents');
+
+  dirDelete(sourceDir);
+  dirDelete(path.join('test', 'nested'));
 });
 
 test('Directory is empty', () => {


### PR DESCRIPTION
## Summary
- Fixes #85 — `archiveExtract()`'s tar branch passed a possibly non-existent `dirPath` to `tar.extract()` as `cwd`. `node-tar` requires `cwd` to already exist and throws `ENOENT: Cannot cd into '...'` otherwise, so fresh `.tgz`/`.tar` installs into an empty data directory (e.g. `studiorack plugins install baconpaul/six-sines@1.1.0` on a clean install) failed.
- The `.zip` (AdmZip) and `.7z` (7zip-min) branches were unaffected — both extractors create their own target directory internally. Only the tar branch was missing this.
- Fix: call `dirCreate(dirPath)` before `tar.extract()`, mirroring what the sibling Installer branch already does explicitly.
- Added a regression test in `tests/helpers/file.test.ts` that builds a real `.tgz` fixture at test time, points `archiveExtract` at a deeply nested directory that doesn't exist yet, and asserts extraction succeeds with correct file contents. Verified this test fails with the old code (`ENOENT: Cannot cd into ...`) and passes with the fix.

## Test plan
- [x] New test fails on `main` (reproduces the reported `ENOENT` error)
- [x] New test passes with the fix
- [x] `npm run check` (format, lint, build, full test suite) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)