### PR TITLE
fix: recognize Linux VST3 bundles without Info.plist

### DIFF
--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -384,6 +384,11 @@ export function filesMove(dirSource: string, dirTarget: string, dirSub: string, 
       if (fileExists(path.join(f, 'manifest.ttl'))) {
         bundleDirs.add(f);
       }
+      // VST3 bundles on Linux (and some Windows builds) are directories without a macOS
+      // Info.plist, so they must be recognized by extension alone.
+      if (path.extname(f).slice(1).toLowerCase() === 'vst3') {
+        bundleDirs.add(f);
+      }
     }
   });
 

--- a/tests/helpers/file.test.ts
+++ b/tests/helpers/file.test.ts
@@ -20,7 +20,9 @@ import {
   dirRead,
   dirRename,
   fileCreate,
+  fileExists,
   fileHash,
+  filesMove,
   fileReadString,
   isSafeArchiveEntryPath,
   // fileCreateJson,
@@ -39,6 +41,7 @@ import {
   getPlatform,
 } from '../../src/helpers/file.js';
 import { PackageInterface } from '../../src/types/Package.js';
+import { pluginFormatDir } from '../../src/types/PluginFormat.js';
 import { apiText } from '../../src/helpers/api.js';
 
 const DIR_APP: string = 'open-audio-stack';
@@ -100,6 +103,36 @@ test('Archive extract creates missing tar target directory', async () => {
 
   dirDelete(sourceDir);
   dirDelete(path.join('test', 'nested'));
+});
+
+test('Files move installs Linux VST3 bundle without Info.plist', () => {
+  // Regression test for https://github.com/open-audio-stack/open-audio-stack-core/issues/82 -
+  // Linux (and some Windows) VST3 bundles are directories without a macOS Info.plist, so they
+  // must still be recognized and moved atomically rather than having their nested .so file
+  // extracted independently.
+  const sourceDir: string = path.join('test', 'vst3-source');
+  const targetDir: string = path.join('test', 'vst3-target');
+  const bundleDir: string = path.join(sourceDir, 'Dexed.vst3', 'Contents', 'x86_64-linux');
+  dirCreate(bundleDir);
+  fileCreate(path.join(bundleDir, 'Dexed.so'), 'fake shared library');
+
+  filesMove(sourceDir, targetDir, path.join('asb2m10', 'dexed', '1.0.1'), pluginFormatDir);
+
+  const installedSo: string = path.join(
+    targetDir,
+    'VST3',
+    'asb2m10',
+    'dexed',
+    '1.0.1',
+    'Dexed.vst3',
+    'Contents',
+    'x86_64-linux',
+    'Dexed.so',
+  );
+  expect(fileExists(installedSo)).toEqual(true);
+
+  dirDelete(sourceDir);
+  dirDelete(targetDir);
 });
 
 test('Directory is empty', () => {


### PR DESCRIPTION
## Summary
- Fixes #82 — `filesMove()`'s bundle-directory detection (`src/helpers/file.ts`) only recognized a directory as a bundle if it had a macOS `Contents/Info.plist` or an LV2 `manifest.ttl`. A Linux (or some Windows) VST3 bundle directory — e.g. `Dexed.vst3/Contents/x86_64-linux/Dexed.so` — has neither, so the `.vst3` directory was never added to `bundleDirs`.
- As a result, the bundle directory itself was skipped entirely, while its nested `.so` file was picked up independently by the per-file extension pass and moved to the generic `VST` folder — never installed as an atomic bundle under `VST3/...`, and losing its internal `Contents/<arch>` structure that hosts expect.
- Fix: recognize directories with a `.vst3` extension as bundles directly, alongside the existing plist/manifest checks, so the whole bundle moves atomically regardless of platform.
- Added a regression test in `tests/helpers/file.test.ts` reproducing the exact Linux VST3 shape from the issue (`Dexed.vst3/Contents/x86_64-linux/Dexed.so`, no `Info.plist`) and asserting the bundle lands intact under `VST3/<slug>/<version>/Dexed.vst3/Contents/x86_64-linux/Dexed.so`.

## Test plan
- [x] New test fails on `main` (nested `.so` extracted independently, bundle never installed under `VST3/`)
- [x] New test passes with the fix
- [x] `npm run check` (format, lint, build, full test suite — 172 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)