### PR TITLE
[feature] Implement clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Common package shared across Open Audio Stack compatible registries, command-lin
 
 This library is built for **audio software developers**. If you are building a plugin manager, DAW, app, command-line tool or website, use `@open-audio-stack/core` to search a registry and download/install packages without writing the distribution and install logic yourself.
 
-The end beneficiaries are the audio software developers'  customers: **musicians and music producers**, who get a more consistent experience installing audio software.
+The end beneficiaries are the audio software developers' customers: **musicians and music producers**, who get a more consistent experience installing audio software.
 
 For the wider project context and strategy, see [Open Audio Stack](https://github.com/open-audio-stack).
 

--- a/specification.md
+++ b/specification.md
@@ -230,6 +230,29 @@ $ manager config get projectsDir
 /Users/username/Documents/Audio
 ```
 
+### Templates directory
+
+Default destination for packages cloned from a template via the `clone` command (see [Clone](#clone)). Same path across all platforms. Users are able to change the path via settings.
+
+| Platform         | Path                              |
+| :--------------- | :-------------------------------- |
+| Mac platform     | `$HOME/Documents/Audio Templates` |
+| Linux platform   | `$HOME/Documents/Audio Templates` |
+| Windows platform | `$HOME\Documents\Audio Templates` |
+
+Recommended sub-directory hierarchy to keep cloned packages separate and easier to manage:  
+`$templates_dir/$registryType/$package_slug/`
+
+For example:  
+`$templates_dir/plugins/kmt/banwer/`
+
+#### Get templates directory
+
+```
+$ manager config get templatesDir
+/Users/username/Documents/Audio Templates
+```
+
 ## Manager
 
 These functions can be run in a browser as part of a website or app. They do not rely on access to the local machine. ManagerLocal extends this with methods to install and manage plugins locally.
@@ -394,21 +417,29 @@ Uninstall a package by slug. Optionally including a version.
 
 ### Clone
 
-Clone a new package from a template.
+Clone a new package from a template hosted as a GitHub repository. This is intended for local plugin/preset/project development: starting a new package from a template, customizing an existing plugin's build, or packaging a plugin whose binaries require manual installation.
+
+Any public `owner/repo` on GitHub can be used as a template — there is no curated template registry. This keeps the feature generic: it works for official Open Audio Stack starter templates as well as a developer's own fork or an unrelated repository they want a local working copy of.
 
 #### Clone logic
 
-1. Check to see if package is already installed
-   1. If installed, return package already installed message
-   2. If not installed, proceed to next step
-2. Download package template to temporary directory and extract contents
-3. Clone package target directory, move template contents into package directory.
+1. Check to see if the package target directory already exists (`$templates_dir/$registryType/$slug`, see [Templates directory](#templates-directory))
+   1. If it exists, return a "package already exists" error
+   2. If not, proceed to next step
+2. Resolve the template repository's default branch, download it as an archive to a temporary directory, and extract its contents
+   1. If the template repository cannot be found, return an error
+3. Move the extracted template contents into the package target directory
 
 #### Clone example
 
 `$ manager <registryType> clone <slug> <template>`
 
+- `<slug>` — the org/package slug for the new package being created, e.g. `kmt/banwer`
+- `<template>` — a GitHub `owner/repo` slug identifying the template repository to clone, e.g. `open-audio-stack/open-audio-stack-template-plugin`
+
 #### Packages fields to populate
+
+Once cloned, the following fields should be populated by hand in the package's own metadata file:
 
 - `audio`
 - `author`

--- a/src/classes/ManagerLocal.ts
+++ b/src/classes/ManagerLocal.ts
@@ -7,6 +7,7 @@ import {
   dirCreate,
   dirDelete,
   dirEmpty,
+  dirExists,
   dirIs,
   dirMove,
   dirRead,
@@ -24,9 +25,16 @@ import {
   isAdmin,
   runCliAsAdmin,
 } from '../helpers/file.js';
-import { isValidSlug, isValidVersion, pathGetSlug, pathGetVersion, toSlug } from '../helpers/utils.js';
+import {
+  isValidGithubRepo,
+  isValidSlug,
+  isValidVersion,
+  pathGetSlug,
+  pathGetVersion,
+  toSlug,
+} from '../helpers/utils.js';
 import { commandExists, getArchitecture, getSystem, isTests } from '../helpers/utilsLocal.js';
-import { apiBuffer } from '../helpers/api.js';
+import { apiBuffer, apiJson } from '../helpers/api.js';
 import { FileInterface } from '../types/File.js';
 import { FileType } from '../types/FileType.js';
 import { RegistryType } from '../types/Registry.js';
@@ -57,6 +65,49 @@ export class ManagerLocal extends Manager {
   isPackageInstalled(slug: string, version: string): boolean {
     const versionDirs: string[] = dirRead(path.join(this.typeDir, '**', slug, version));
     return versionDirs.length > 0;
+  }
+
+  async clone(slug: string, template: string) {
+    this.log('clone', slug, template);
+    if (!isValidSlug(slug)) throw new Error(`Invalid package slug: ${slug}`);
+    if (!isValidGithubRepo(template)) throw new Error(`Invalid template repo: ${template}`);
+
+    // "Package already installed" (per spec) doesn't apply to authoring a new package from a
+    // template - there's no runtime install to check. The equivalent guard here is: don't
+    // clobber a package that's already been scaffolded at the target directory.
+    const dirTarget: string = path.join(this.config.get('templatesDir') as string, this.type, slug);
+    if (dirExists(dirTarget)) throw new Error(`Package ${slug} already exists at ${dirTarget}`);
+
+    // Resolve the template repo's default branch via the GitHub API rather than guessing
+    // main vs master, and use the same lookup to give a clear error for a nonexistent repo.
+    const repoInfo: { default_branch?: string } = await apiJson(`https://api.github.com/repos/${template}`);
+    if (!repoInfo.default_branch) throw new Error(`Template ${template} not found on GitHub`);
+    const branch: string = repoInfo.default_branch;
+    const templateUrl = `https://github.com/${template}/archive/refs/heads/${branch}.zip`;
+
+    // Download to a template-scoped cache dir so repeat clones of the same template reuse it,
+    // matching the download-caching pattern used by install().
+    const dirDownloads: string = path.join(this.config.get('appDir') as string, 'downloads', 'templates', template);
+    dirCreate(dirDownloads);
+    const zipPath: string = path.join(dirDownloads, `${branch}.zip`);
+    if (!fileExists(zipPath)) {
+      const fileBuffer: ArrayBuffer = await apiBuffer(templateUrl);
+      fileCreate(zipPath, Buffer.from(fileBuffer));
+    }
+
+    const dirExtract: string = path.join(this.config.get('appDir') as string, 'temp', 'templates', template);
+    dirDelete(dirExtract);
+    await archiveExtract(zipPath, dirExtract);
+
+    // GitHub codeload zips always contain exactly one top-level "<repo>-<branch>" folder.
+    const extractedDirs: string[] = dirRead(path.join(dirExtract, '*')).filter(dirIs);
+    const dirSource: string = extractedDirs[0] || dirExtract;
+
+    dirCreate(path.dirname(dirTarget));
+    dirMove(dirSource, dirTarget);
+    dirDelete(dirExtract);
+
+    return dirTarget;
   }
 
   async create() {

--- a/src/helpers/configLocal.ts
+++ b/src/helpers/configLocal.ts
@@ -1,6 +1,6 @@
 import { ConfigInterface } from '../types/Config.js';
 import { configDefaults } from './config.js';
-import { dirApp, dirApps, dirPlugins, dirPresets, dirProjects } from './file.js';
+import { dirApp, dirApps, dirPlugins, dirPresets, dirProjects, dirTemplates } from './file.js';
 
 export function configDefaultsLocal(): ConfigInterface {
   return {
@@ -10,5 +10,6 @@ export function configDefaultsLocal(): ConfigInterface {
     pluginsDir: dirPlugins(),
     presetsDir: dirPresets(),
     projectsDir: dirProjects(),
+    templatesDir: dirTemplates(),
   };
 }

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -209,6 +209,10 @@ export function dirProjects() {
   return path.join(os.homedir(), 'Documents', 'Audio');
 }
 
+export function dirTemplates() {
+  return path.join(os.homedir(), 'Documents', 'Audio Templates');
+}
+
 export function dirApps() {
   if (getSystem() === SystemType.Win) return path.join(os.homedir(), 'AppData', 'Local', 'Programs');
   else if (getSystem() === SystemType.Mac) return path.join('/Applications');

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -62,3 +62,11 @@ export function isValidSlug(slug: string): boolean {
 export function isValidVersion(version: string): boolean {
   return semver.valid(version) !== null;
 }
+
+// Matches a GitHub "owner/repo" slug, e.g. as used by clone() to identify a template repo to
+// download. Deliberately stricter than GitHub's own username rules (which allow leading/
+// trailing/consecutive hyphens in some legacy cases) since this value is used to build a
+// download URL - reject anything ambiguous rather than pass it through.
+export function isValidGithubRepo(repo: string): boolean {
+  return /^[\w.-]+\/[\w.-]+$/.test(repo);
+}

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -4,6 +4,7 @@ export interface ConfigInterface {
   pluginsDir?: string;
   presetsDir?: string;
   projectsDir?: string;
+  templatesDir?: string;
   registries?: ConfigRegistry[];
   version?: string;
 }

--- a/tests/classes/ConfigLocal.test.ts
+++ b/tests/classes/ConfigLocal.test.ts
@@ -24,6 +24,7 @@ const CONFIG: ConfigInterface = {
   pluginsDir: path.join(APP_DIR, 'installed', 'plugins'),
   presetsDir: path.join(APP_DIR, 'installed', 'presets'),
   projectsDir: path.join(APP_DIR, 'installed', 'projects'),
+  templatesDir: path.join(APP_DIR, 'templates'),
 };
 
 beforeAll(() => {
@@ -52,6 +53,8 @@ test('Set and get value', () => {
   expect(config.get('pluginsDir')).toEqual(CONFIG_LOCAL_TEST.pluginsDir);
   config.set('presetsDir', CONFIG_LOCAL_TEST.presetsDir);
   config.set('projectsDir', CONFIG_LOCAL_TEST.projectsDir);
+  config.set('templatesDir', CONFIG_LOCAL_TEST.templatesDir);
+  expect(config.get('templatesDir')).toEqual(CONFIG_LOCAL_TEST.templatesDir);
 });
 
 test('Config export', () => {

--- a/tests/classes/ManagerLocal.test.ts
+++ b/tests/classes/ManagerLocal.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../data/Project';
 import { CONFIG_LOCAL_TEST } from '../data/Config';
 import { ManagerLocal } from '../../src/classes/ManagerLocal';
-import { dirDelete, fileReadJson } from '../../src/helpers/file';
+import { dirDelete, dirEmpty, dirExists, fileReadJson } from '../../src/helpers/file';
 import * as fileHelpers from '../../src/helpers/file';
 import * as utilsLocalHelpers from '../../src/helpers/utilsLocal';
 import { RegistryType } from '../../src/types/Registry';
@@ -34,6 +34,7 @@ beforeAll(() => {
   dirDelete(path.join(APP_DIR, 'export'));
   dirDelete(path.join(APP_DIR, 'installed'));
   dirDelete(path.join(APP_DIR, 'plugins'));
+  dirDelete(path.join(APP_DIR, 'templates'));
 });
 
 test('Manager Local scan local directory', () => {
@@ -170,4 +171,33 @@ test('Project sync, install project, add new dependency, remove new dependency',
 
   const pkgNoDeps = await manager.uninstallDependency(PLUGIN_PACKAGE.slug, '1.3.4', PROJECT_PATH);
   expect(omitDownloads(pkgNoDeps)).toEqual(omitDownloads(PROJECT_NO_DEPS));
+});
+
+test('Clone package from GitHub template', async () => {
+  const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
+  const dirTarget: string = await manager.clone('template-org/template-plugin', 'octocat/Hello-World');
+  expect(dirExists(dirTarget)).toEqual(true);
+  expect(dirEmpty(dirTarget)).toEqual(false);
+});
+
+test('Clone throws when target directory already exists', async () => {
+  const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
+  await expect(manager.clone('template-org/template-plugin', 'octocat/Hello-World')).rejects.toThrow('already exists');
+});
+
+test('Clone throws for invalid package slug', async () => {
+  const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
+  await expect(manager.clone('Invalid Slug', 'octocat/Hello-World')).rejects.toThrow('Invalid package slug');
+});
+
+test('Clone throws for invalid template repo', async () => {
+  const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
+  await expect(manager.clone('template-org/template-plugin-2', 'not a repo')).rejects.toThrow('Invalid template repo');
+});
+
+test('Clone throws for nonexistent template repo', async () => {
+  const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
+  await expect(
+    manager.clone('template-org/template-plugin-3', 'open-audio-stack/this-repo-does-not-exist-xyz123'),
+  ).rejects.toThrow('not found on GitHub');
 });

--- a/tests/data/Config.ts
+++ b/tests/data/Config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { dirApp, dirApps, dirPlugins, dirPresets, dirProjects } from '../../src/helpers/file';
+import { dirApp, dirApps, dirPlugins, dirPresets, dirProjects, dirTemplates } from '../../src/helpers/file';
 import { ConfigInterface } from '../../src/types/Config';
 
 export const CONFIG: ConfigInterface = {
@@ -19,6 +19,7 @@ export const CONFIG_LOCAL: ConfigInterface = {
   pluginsDir: dirPlugins(),
   presetsDir: dirPresets(),
   projectsDir: dirProjects(),
+  templatesDir: dirTemplates(),
 };
 
 export const CONFIG_LOCAL_TEST: ConfigInterface = {
@@ -28,4 +29,5 @@ export const CONFIG_LOCAL_TEST: ConfigInterface = {
   pluginsDir: path.join('test', 'installed', 'plugins'),
   presetsDir: path.join('test', 'installed', 'presets'),
   projectsDir: path.join('test', 'installed', 'projects'),
+  templatesDir: path.join('test', 'templates'),
 };

--- a/tests/helpers/file.test.ts
+++ b/tests/helpers/file.test.ts
@@ -19,6 +19,7 @@ import {
   dirProjects,
   dirRead,
   dirRename,
+  dirTemplates,
   fileCreate,
   fileExists,
   fileHash,
@@ -198,6 +199,14 @@ test('Directory projects', () => {
     expect(dirProjects()).toEqual(`${os.homedir()}/Documents/Audio`);
   } else {
     expect(dirProjects()).toEqual(`${os.homedir()}/Documents/Audio`);
+  }
+});
+
+test('Directory templates', () => {
+  if (process.platform === 'win32') {
+    expect(dirTemplates()).toEqual(`${os.homedir()}\\Documents\\Audio Templates`);
+  } else {
+    expect(dirTemplates()).toEqual(`${os.homedir()}/Documents/Audio Templates`);
   }
 });
 

--- a/tests/helpers/utils.test.ts
+++ b/tests/helpers/utils.test.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { expect, test } from 'vitest';
 import {
   inputGetParts,
+  isValidGithubRepo,
   pathGetDirectory,
   pathGetExt,
   pathGetFilename,
@@ -47,6 +48,15 @@ test('Path get slug', () => {
   expect(pathGetSlug(path.join(PLUGIN_ORG, PLUGIN_ID, PLUGIN_VERSION, 'suffix-dir', 'surge.vst3'), path.sep)).toEqual(
     PLUGIN_SLUG,
   );
+});
+
+test('Is valid GitHub repo', () => {
+  expect(isValidGithubRepo('octocat/Hello-World')).toEqual(true);
+  expect(isValidGithubRepo('surge-synthesizer/surge')).toEqual(true);
+  expect(isValidGithubRepo('open-audio-stack')).toEqual(false);
+  expect(isValidGithubRepo('too/many/slashes')).toEqual(false);
+  expect(isValidGithubRepo('')).toEqual(false);
+  expect(isValidGithubRepo('org/repo name')).toEqual(false);
 });
 
 test('Path get version', () => {


### PR DESCRIPTION
## Summary
- Implements `ManagerLocal.clone(slug, template)`, the previously-unimplemented `clone` command from `specification.md` (flagged in an internal spec-compliance audit).
- `template` is a literal GitHub `owner/repo` slug — any public repo can be cloned as a local scaffold, not just a curated template registry. Useful for starting a new plugin/preset/project from a template, customizing an existing plugin's build, or manually packaging a plugin with bad binaries.
- Adds a new `templatesDir` config setting (mirrors `pluginsDir`/`presetsDir`/`projectsDir`), defaulting to `$HOME/Documents/Audio Templates` on all platforms. Cloned packages land at `templatesDir/<registryType>/<slug>`.
- Resolves the template repo's default branch via the GitHub API (no guessing `main` vs `master`), downloads/caches the archive, extracts it with the existing zip-slip-safe `archiveExtract`, and moves it into place.
- Updates `specification.md`'s Clone section and adds a new Templates directory section to match.

## Test plan
- [x] `npm run check` passes (format, lint, build, tests — 181/181)
- [x] New tests cover: successful clone against `octocat/Hello-World`, target-already-exists error, invalid package slug, invalid template repo format, nonexistent template repo
- [x] New `isValidGithubRepo()` and `dirTemplates()` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)