### PR TITLE
[fix] Make create command persist metadata instead of always throwing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Common package shared across Open Audio Stack compatible registries, command-lin
 
 This library is built for **audio software developers**. If you are building a plugin manager, DAW, app, command-line tool or website, use `@open-audio-stack/core` to search a registry and download/install packages without writing the distribution and install logic yourself.
 
-The end beneficiaries are the audio software developers'  customers: **musicians and music producers**, who get a more consistent experience installing audio software.
+The end beneficiaries are the audio software developers' customers: **musicians and music producers**, who get a more consistent experience installing audio software.
 
 For the wider project context and strategy, see [Open Audio Stack](https://github.com/open-audio-stack).
 

--- a/specification.md
+++ b/specification.md
@@ -426,7 +426,22 @@ Clone a new package from a template.
 
 ### Create
 
-Create new package metadata:  
+Create new package metadata. Prompts the developer for package details, then writes them to `<path>/index.json`.
+
+`<path>` is optional:
+
+- `<path>` — write `index.json` into this directory
+- None — use the current directory
+
+#### Create logic
+
+1. Prompt for and collect the package fields listed below.
+2. `files` (and, for Presets/Projects, `plugins`) start empty — there is no built/published release yet for a package that's just been created. Populating them is a separate, later step, once a release has been built (see [Install package](#install-package) for the metadata shape a release's `files` entries must have).
+3. Validate the collected fields and report any errors/recommendations to the developer (e.g. missing `files`) — these are informational, not fatal. A newly created package is expected to be incomplete.
+4. Write the metadata to `<path>/index.json`, creating `<path>` if it doesn't already exist.
+
+#### Create example
+
 `$ manager <registryType> create <path>`
 
 #### Project fields to populate

--- a/src/classes/ManagerLocal.ts
+++ b/src/classes/ManagerLocal.ts
@@ -33,7 +33,7 @@ import { RegistryType } from '../types/Registry.js';
 import { PluginFormat, pluginFormatDir } from '../types/PluginFormat.js';
 import { ConfigInterface } from '../types/Config.js';
 import { ConfigLocal } from './ConfigLocal.js';
-import { packageCompatibleFiles } from '../helpers/package.js';
+import { packageCompatibleFiles, packageErrors, packageRecommendations } from '../helpers/package.js';
 import { presetFormatDir } from '../types/PresetFormat.js';
 import { projectFormatDir } from '../types/ProjectFormat.js';
 import { FileFormat } from '../types/FileFormat.js';
@@ -59,7 +59,7 @@ export class ManagerLocal extends Manager {
     return versionDirs.length > 0;
   }
 
-  async create() {
+  async create(dirPath?: string) {
     // TODO Rewrite this code after prototype is proven.
     const pkgQuestions = [
       {
@@ -137,16 +137,32 @@ export class ManagerLocal extends Manager {
     ];
 
     const pkgVersionAnswers = await inquirer.prompt(pkgVersionQuestions as any);
-    // TODO prompt for each file.
+    // TODO prompt for each file. Left empty here deliberately - a freshly created package has no
+    // built/published release yet, so there's nothing to fill `files` with. createSave() reports
+    // this as a recommendation rather than treating it as a fatal validation error.
     pkgVersionAnswers.files = [];
     if (this.type === RegistryType.Presets || this.type === RegistryType.Projects) {
       pkgVersionAnswers.plugins = [];
     }
-    this.log(pkgVersionAnswers);
-    const pkg = new Package(`${pkgAnswers.org}/${pkgAnswers.package}`);
-    pkg.addVersion(pkgAnswers.version, pkgVersionAnswers as PackageVersion);
-    this.log(JSON.stringify(pkg.getReport(), null, 2));
-    this.addPackage(pkg);
+    return this.createSave(`${pkgAnswers.org}/${pkgAnswers.package}`, pkgVersionAnswers as PackageVersion, dirPath);
+  }
+
+  // Split out from create() so package persistence is testable without driving inquirer's
+  // interactive prompts. A freshly created package is expected to be incomplete (e.g. `files`
+  // stays empty until a release is built and published) so, unlike Package.addVersion() which
+  // throws on any validation error, this only logs errors/recommendations as a report and always
+  // persists - the point of `create` is to scaffold the metadata file for a developer to fill in
+  // over time, not to produce a fully valid, publishable package on the first pass.
+  createSave(slug: string, pkgVersion: PackageVersion, dirPath?: string) {
+    if (!isValidSlug(slug)) throw new Error(`Invalid package slug: ${slug}`);
+    const errors = packageErrors(pkgVersion);
+    const recs = packageRecommendations(pkgVersion);
+    this.logReport(slug, errors, recs);
+
+    const filePath: string = path.join(dirPath || '.', 'index.json');
+    dirCreate(path.dirname(filePath));
+    packageSaveFile(pkgVersion, filePath);
+    return filePath;
   }
 
   scan(ext = 'json', installable = true) {

--- a/tests/classes/ManagerLocal.test.ts
+++ b/tests/classes/ManagerLocal.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../data/Project';
 import { CONFIG_LOCAL_TEST } from '../data/Config';
 import { ManagerLocal } from '../../src/classes/ManagerLocal';
-import { dirDelete, fileReadJson } from '../../src/helpers/file';
+import { dirDelete, fileExists, fileReadJson } from '../../src/helpers/file';
 import * as fileHelpers from '../../src/helpers/file';
 import * as utilsLocalHelpers from '../../src/helpers/utilsLocal';
 import { RegistryType } from '../../src/types/Registry';
@@ -34,6 +34,7 @@ beforeAll(() => {
   dirDelete(path.join(APP_DIR, 'export'));
   dirDelete(path.join(APP_DIR, 'installed'));
   dirDelete(path.join(APP_DIR, 'plugins'));
+  dirDelete(path.join(APP_DIR, 'create'));
 });
 
 test('Manager Local scan local directory', () => {
@@ -170,4 +171,37 @@ test('Project sync, install project, add new dependency, remove new dependency',
 
   const pkgNoDeps = await manager.uninstallDependency(PLUGIN_PACKAGE.slug, '1.3.4', PROJECT_PATH);
   expect(omitDownloads(pkgNoDeps)).toEqual(omitDownloads(PROJECT_NO_DEPS));
+});
+
+test('Create save persists an incomplete package without throwing', () => {
+  const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
+  const pkgVersion: PackageVersion = { ...PLUGIN, files: [] };
+  const dirTarget: string = path.join(APP_DIR, 'create', 'test-org', 'test-plugin');
+
+  const filePath: string = manager.createSave('test-org/test-plugin', pkgVersion, dirTarget);
+
+  expect(filePath).toEqual(path.join(dirTarget, 'index.json'));
+  expect(fileExists(filePath)).toEqual(true);
+  const saved = fileReadJson(filePath);
+  expect(saved.files).toEqual([]);
+  expect(saved.name).toEqual(PLUGIN.name);
+});
+
+test('Create save defaults to index.json in the given directory root', () => {
+  const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
+  const pkgVersion: PackageVersion = { ...PLUGIN, files: [] };
+  const dirTarget: string = path.join(APP_DIR, 'create', 'no-nested-version');
+
+  const filePath: string = manager.createSave('test-org/no-nested-version', pkgVersion, dirTarget);
+
+  expect(filePath).toEqual(path.join(dirTarget, 'index.json'));
+  expect(fileExists(filePath)).toEqual(true);
+});
+
+test('Create save throws for invalid package slug', () => {
+  const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
+  const pkgVersion: PackageVersion = { ...PLUGIN, files: [] };
+  expect(() => manager.createSave('Invalid Slug', pkgVersion, path.join(APP_DIR, 'create', 'invalid'))).toThrow(
+    'Invalid package slug',
+  );
 });


### PR DESCRIPTION
## Summary
- `create()` was fundamentally broken: it hard-codes `files = []` for a brand-new package (there's no built release yet), but `Package.addVersion()` requires `files.min(1)` and throws on any validation error — so every invocation threw, after the developer answered ~10 interactive prompts. It also never wrote anything to disk despite the spec's `create <path>` implying persisted metadata. (Flagged in an internal spec-compliance audit; zero test coverage existed, which is why this shipped unnoticed.)
- Splits persistence out into `ManagerLocal.createSave(slug, pkgVersion, dirPath)`: reports validation errors/recommendations via the existing report mechanism instead of throwing (a freshly created package is expected to be incomplete — `files` legitimately stays empty until a release is built and published), and always writes `<path>/index.json`, creating the directory if needed.
- `create()` now accepts an optional `dirPath` argument (defaults to the current directory), matching `$ manager <registryType> create <path>`.
- This also makes the persistence logic testable independently of inquirer's interactive prompts.
- Updated `specification.md`'s Create section to document the `<path>` default and the non-fatal validation behavior.

## Test plan
- [x] `npm run check` passes (format, lint, build, tests — 177/177)
- [x] New tests: persists an incomplete package without throwing, defaults to `index.json` in the given directory, throws for an invalid package slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)