### PR TITLE
[fix] Correct dirPlugins() default paths to match specification.md

### DIFF
--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -190,9 +190,13 @@ export function dirPackage(pkg: PackageInterface) {
 }
 
 export function dirPlugins() {
-  if (getSystem() === SystemType.Win) return path.join('Program Files', 'Common Files');
+  if (getSystem() === SystemType.Win)
+    return process.env['ProgramFiles(x86)'] || path.join('C:', 'Program Files (x86)', 'Common Files');
   else if (getSystem() === SystemType.Mac) return path.join(os.homedir(), 'Library', 'Audio', 'Plug-ins');
-  return path.join('usr', 'local', 'lib');
+  // Under $HOME rather than the system-wide /usr/local/lib, matching the spec - this keeps the
+  // default writable without elevation, consistent with the unprivileged archive-install path
+  // (see ManagerLocal.install()).
+  return path.join(os.homedir(), 'usr', 'local', 'lib');
 }
 
 export function dirPresets() {

--- a/tests/helpers/file.test.ts
+++ b/tests/helpers/file.test.ts
@@ -174,11 +174,11 @@ test('Directory package', () => {
 
 test('Directory plugins', () => {
   if (process.platform === 'win32') {
-    expect(dirPlugins()).toEqual('Program Files\\Common Files');
+    expect(dirPlugins()).toEqual(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)\\Common Files');
   } else if (process.platform === 'darwin') {
     expect(dirPlugins()).toEqual(`${os.homedir()}/Library/Audio/Plug-ins`);
   } else {
-    expect(dirPlugins()).toEqual('usr/local/lib');
+    expect(dirPlugins()).toEqual(`${os.homedir()}/usr/local/lib`);
   }
 });
 


### PR DESCRIPTION
## Summary
- `dirPlugins()` returned bare relative paths that didn't match the spec's directory table (flagged in an internal spec-compliance audit):
  - **Linux**: spec says `$HOME/usr/local/lib` — code returned relative `usr/local/lib` with no `$HOME` and no leading slash, resolving against `process.cwd()` instead of a stable location.
  - **Windows**: spec says `C:\Program Files (x86)\Common Files` — code returned relative `Program Files\Common Files`, missing the drive letter and `(x86)`.
  - Mac was already correct.
- Linux now joins onto `os.homedir()`, which also keeps the default writable without elevation — consistent with the unprivileged archive-install path added in `ManagerLocal.install()` for issue #83.
- Windows now prefers the `%ProgramFiles(x86)%` env var (matching the existing `%APPDATA%` pattern already used in `dirApp()`), falling back to the spec's literal path.
- Updated `tests/helpers/file.test.ts`, which had been asserting the old, buggy values — this is why the bug went unnoticed.

**Note:** this changes the default `pluginsDir` for existing installs on Linux/Windows. Anyone relying on the old (broken) default location will need to move their files or reconfigure `pluginsDir`.

## Test plan
- [x] `npm run check` passes locally (format, lint, build, tests — 191/191, macOS)
- [x] CI covers all three platforms (ubuntu-latest, macos-latest, windows-latest) — watching for green across all three since this specifically touches the Windows/Linux code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)