### PR TITLE
[fix] Use execFile instead of a shell string in commandExists()

### DIFF
--- a/src/helpers/utilsLocal.ts
+++ b/src/helpers/utilsLocal.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { SystemType } from '../types/SystemType.js';
 import { Architecture } from '../types/Architecture.js';
 
@@ -21,9 +21,14 @@ export function isTests() {
   return jest || vitest;
 }
 
+// Only ever called with literal values today ('dpkg'/'rpm' in ManagerLocal.install()'s Linux
+// branch), but uses execFile (no shell) rather than exec with a shell string on principle -
+// every other command execution in this codebase avoids building shell strings from values that
+// could someday trace back to registry/package metadata, and this should be no exception for
+// whoever calls it next.
 export function commandExists(cmd: string): Promise<boolean> {
   return new Promise(resolve => {
-    exec(`command -v ${cmd}`, (error, stdout) => {
+    execFile('which', [cmd], (error, stdout) => {
       resolve(Boolean(stdout.trim()) && !error);
     });
   });

--- a/tests/helpers/utilsLocal.test.ts
+++ b/tests/helpers/utilsLocal.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { getArchitecture, getSystem, isTests } from '../../src/helpers/utilsLocal';
+import { commandExists, getArchitecture, getSystem, isTests } from '../../src/helpers/utilsLocal';
 
 test('Get Architecture', () => {
   if (process.arch === 'arm') {
@@ -25,4 +25,13 @@ test('Get System', () => {
 
 test('Is tests', () => {
   expect(isTests()).toEqual(true);
+});
+
+test('Command exists', async () => {
+  // `which` isn't available as a standalone command on plain Windows (unlike Linux/Mac, which
+  // is the only place commandExists() is actually used - ManagerLocal.install()'s dpkg/rpm
+  // check).
+  if (process.platform === 'win32') return;
+  expect(await commandExists('node')).toEqual(true);
+  expect(await commandExists('this-command-should-not-exist-xyz123')).toEqual(false);
 });


### PR DESCRIPTION
## Summary
- `commandExists()` was the one function in the local-execution surface that built a shell command string (`exec(\`command -v \${cmd}\`)`) instead of using `execFile`/`execFileSync` with an argv array, unlike every other command execution in this codebase — which has extensive commentary explaining why shell strings are avoided wherever a value could trace back to registry/package metadata. It's only ever called with literal values today (`'dpkg'`/`'rpm'` in `ManagerLocal.install()`'s Linux branch), so there's no live injection vector, but it was a landmine for the next contributor who calls it with something dynamic. Flagged in an internal spec-compliance audit.
- Switched to `execFile('which', [cmd], ...)` — `which` is a real executable (unlike `command`, a shell builtin with no standalone binary), so this avoids a shell entirely rather than just working around it.
- Also adds `commandExists()`'s first test coverage.

## Test plan
- [x] `npm run check` passes (format, lint, build, tests — 203/203)
- [x] New test: `commandExists('node')` → true, `commandExists('this-command-should-not-exist-xyz123')` → false (skipped on Windows, where `commandExists` isn't actually used and `which` isn't a standalone command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)