### PR TITLE
refactor: make packageIsVerified() actually short-circuit

### DIFF
--- a/src/helpers/package.ts
+++ b/src/helpers/package.ts
@@ -244,14 +244,9 @@ export function packageYamlToJs(pkgYaml: string) {
 
 export function packageIsVerified(slug: string, pkgVersion: PackageVersion) {
   const org: string = slug.split('/')[0];
-  let verified: boolean = true;
-  pkgVersion.files.forEach(file => {
+  return pkgVersion.files.every(file => {
     const url: string = file.url.toLowerCase();
     const root: string = url.startsWith('https://github.com/') ? 'https://github.com/' + org + '/' : `https://${org}.`;
-    if (!url.startsWith(root)) {
-      verified = false;
-      return;
-    }
+    return url.startsWith(root);
   });
-  return verified;
 }

--- a/tests/helpers/package.test.ts
+++ b/tests/helpers/package.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 import {
   packageCompatibleFiles,
   packageDownloadsTotal,
+  packageIsVerified,
   packageRecommendations,
   packageVersionLatest,
   PackageVersionValidator,
@@ -136,6 +137,24 @@ test('Package compatible files returns empty when only unsupported formats exist
     [FileFormat.RedHatPackage],
   );
   expect(excludedResult).toHaveLength(0);
+});
+
+test('Package is verified when every file url matches the org', () => {
+  expect(packageIsVerified('surge-synthesizer/surge', PLUGIN)).toEqual(true);
+});
+
+test('Package is not verified when any file url does not match the org', () => {
+  const pluginWithForeignFile: PackageVersion = {
+    ...PLUGIN,
+    files: [
+      ...PLUGIN.files,
+      {
+        ...PLUGIN.files[0],
+        url: 'https://github.com/someone-else/unrelated/releases/download/1.0.0/file.deb',
+      },
+    ],
+  };
+  expect(packageIsVerified('surge-synthesizer/surge', pluginWithForeignFile)).toEqual(false);
 });
 
 test('Package compatible files respects exclusions when alternatives exist', () => {


### PR DESCRIPTION
## Summary
- The `return` inside `pkgVersion.files.forEach()` only exited that iteration's callback, not the outer function, so it kept scanning every remaining file even after `verified` was already `false`. Harmless today (files arrays are capped at 256 by the validator) but flagged as a nitpick in an internal spec-compliance audit.
- Rewrote using `files.every()`, which is both the more direct expression of the "verified iff every file matches" semantic and actually short-circuits on the first non-matching file.
- Also adds this function's first test coverage (previously only exercised indirectly through fixtures that all happened to be `verified: true`).

## Test plan
- [x] `npm run check` passes (format, lint, build, tests — 207/207)
- [x] New tests: all-matching files → verified; one non-matching file → not verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)