### PR TITLE
[fix] Add request timeout and bounded retry to network requests

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -309,6 +309,15 @@ For example, on Windows 11 on Arm devices supporting ARM64EC (Emulation Compatib
 
 The best practice is to allow users to manually set a Desired Platform in the manager's configuration, overriding the auto-detected architecture — see [Desired platform](#desired-platform).
 
+### Network requests
+
+Every network request a manager makes — syncing a registry, downloading a package file, downloading a clone template — should apply a request timeout and a limited retry policy, rather than waiting indefinitely for a response:
+
+1. Apply a timeout (a default in the 10-30 second range is reasonable) to each request. If it elapses, abort the request and treat it as a failed attempt.
+2. Retry failed attempts a small, bounded number of times (once is sufficient) with a short backoff between attempts, but only for failures that are plausibly transient: the request couldn't be sent/receive a response at all (including a timeout as in step 1), or the server responded with a 5xx status.
+3. Do not retry a 4xx response — it will fail identically on every attempt (e.g. a template repository that doesn't exist, or a malformed registry URL), so retrying only delays surfacing a real, permanent error to the caller.
+4. Once retries are exhausted, treat the request as failed for the purposes of the calling operation's own error handling — e.g. a registry that never responds within its retry budget is "unreachable" for [Sync logic](#sync-logic) step 2.1 just as if the connection had been refused immediately.
+
 ### Sync
 
 The purpose of remote syncing is to call multiple registries and aggregate remote packages into a precalculated index/cache, which speeds up any subsequent operations performed by the app. In most cases the manager will use this feature internally and the user will not need to use it directly.

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,20 +1,76 @@
 import { log } from './utils.js';
 
-async function apiFetch(url: string): Promise<Response> {
+export interface ApiRequestOptions {
+  // Abort the request if no response is received within this many milliseconds. Without this, a
+  // registry or file host that accepts the connection but never responds hangs sync()/install()/
+  // clone() forever - there is no other timeout anywhere in the request path.
+  timeoutMs?: number;
+  // Number of additional attempts after the first, for retryable failures only (see isRetryable).
+  retries?: number;
+  // Base delay before the first retry; doubles on each subsequent attempt.
+  retryDelayMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_RETRIES = 1;
+const DEFAULT_RETRY_DELAY_MS = 300;
+
+// Thrown for a non-2xx HTTP response, as opposed to a network-level failure (DNS, connection
+// reset, our own timeout abort) which surfaces as whatever error fetch()/AbortController itself
+// throws. Kept as a distinct type (`status` field) so isRetryable() below - and callers that want
+// to - can tell "the server answered but refused/failed the request" apart from "we couldn't
+// reach a server at all".
+export class ApiHttpError extends Error {
+  status: number;
+  constructor(status: number, statusText: string, url: string) {
+    super(`Request failed: ${status} ${statusText} (${url})`);
+    this.status = status;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Retries only cover failures that are plausibly transient: network-level errors (including our
+// own timeout abort) and 5xx server responses. A 4xx fails identically on every attempt - e.g.
+// clone()'s "template not found" or a malformed registry url - so retrying it would only delay
+// surfacing a real, permanent error to the caller.
+function isRetryable(error: unknown): boolean {
+  if (error instanceof ApiHttpError) return error.status >= 500;
+  return true;
+}
+
+async function apiFetch(url: string, options: ApiRequestOptions = {}): Promise<Response> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, retries = DEFAULT_RETRIES, retryDelayMs = DEFAULT_RETRY_DELAY_MS } = options;
   log('⤓', url);
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Request failed: ${res.status} ${res.statusText} (${url})`);
-  return res;
+
+  for (let attempt = 0; ; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) throw new ApiHttpError(res.status, res.statusText, url);
+      return res;
+    } catch (err) {
+      const isAbort = Boolean(err) && typeof err === 'object' && (err as { name?: string }).name === 'AbortError';
+      const error = isAbort ? new Error(`Request timed out after ${timeoutMs}ms (${url})`) : err;
+      if (attempt >= retries || !isRetryable(error)) throw error;
+      await delay(retryDelayMs * 2 ** attempt);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
 }
 
-export async function apiBuffer(url: string): Promise<ArrayBuffer> {
-  return (await apiFetch(url)).arrayBuffer();
+export async function apiBuffer(url: string, options?: ApiRequestOptions): Promise<ArrayBuffer> {
+  return (await apiFetch(url, options)).arrayBuffer();
 }
 
-export async function apiJson(url: string): Promise<any> {
-  return (await apiFetch(url)).json();
+export async function apiJson(url: string, options?: ApiRequestOptions): Promise<any> {
+  return (await apiFetch(url, options)).json();
 }
 
-export async function apiText(url: string): Promise<string> {
-  return (await apiFetch(url)).text();
+export async function apiText(url: string, options?: ApiRequestOptions): Promise<string> {
+  return (await apiFetch(url, options)).text();
 }

--- a/tests/helpers/api.test.ts
+++ b/tests/helpers/api.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 import { apiBuffer, apiJson, apiText } from '../../src/helpers/api';
 
 const API_URL: string = 'https://jsonplaceholder.typicode.com/todos/1';
@@ -31,4 +31,57 @@ test('Get json', async () => {
 
 test('Get raw buffer', async () => {
   expect(await apiBuffer(API_URL)).toEqual(API_BUFFER);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('Retries once on a transient network failure then succeeds', async () => {
+  const fetchMock = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('socket hang up'))
+    .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+  vi.stubGlobal('fetch', fetchMock);
+
+  const result = await apiJson('https://example.invalid/retry', { retryDelayMs: 1 });
+  expect(result).toEqual({ ok: true });
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+test('Does not retry a 4xx response', async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response('Not Found', { status: 404, statusText: 'Not Found' }));
+  vi.stubGlobal('fetch', fetchMock);
+
+  await expect(apiJson('https://example.invalid/missing', { retryDelayMs: 1 })).rejects.toThrow(
+    'Request failed: 404 Not Found',
+  );
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test('Retries a 5xx response and gives up after exhausting retries', async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response('Boom', { status: 503, statusText: 'Service Unavailable' }));
+  vi.stubGlobal('fetch', fetchMock);
+
+  await expect(apiJson('https://example.invalid/flaky', { retries: 2, retryDelayMs: 1 })).rejects.toThrow(
+    'Request failed: 503',
+  );
+  expect(fetchMock).toHaveBeenCalledTimes(3);
+});
+
+test('Aborts and reports a timeout if the response never arrives', async () => {
+  const fetchMock = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+    return new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => {
+        const err = new Error('The operation was aborted');
+        err.name = 'AbortError';
+        reject(err);
+      });
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  await expect(apiText('https://example.invalid/slow', { timeoutMs: 10, retries: 0 })).rejects.toThrow(
+    'Request timed out after 10ms',
+  );
 });


### PR DESCRIPTION
## Summary
- `apiFetch()` (`helpers/api.ts`) had no timeout — a registry or file host that accepts a TCP connection but never sends a response hung `sync()`, `install()`'s file download, and `clone()`'s template download indefinitely.
- Adds an `AbortController`-based timeout (default 15s) and a single bounded retry with exponential backoff, but **only** for plausibly-transient failures: network-level errors (including the timeout abort) and 5xx responses. 4xx responses are never retried since they fail identically every time (e.g. `clone()`'s "template not found").
- Both `timeoutMs` and `retries`/`retryDelayMs` are configurable per-call via a new `ApiRequestOptions` param on `apiJson`/`apiBuffer`/`apiText`, with sane defaults so no call site needed to change.
- Documents the policy in `specification.md` under a new "Network requests" section (before "Sync"), since two independently-built managers implementing this spec should apply comparable timeout/retry behavior for predictable interop — the spec previously said nothing about request timeouts at all.

This is item 1 of the architectural review in `review.md` (Critical Blocker #2: "No timeout on any network call").

## Test plan
- [x] Added unit tests mocking `global.fetch` to cover: retry-then-succeed on a transient failure, no retry on 4xx, retry-exhaustion on repeated 5xx, and timeout-abort behavior.
- [x] Existing live-network tests (`apiText`/`apiJson`/`apiBuffer` against a real endpoint, and `Manager.sync()` against the real default registry) still pass unmodified — defaults don't add latency on the success path.
- [x] `npm run check` (format, lint, build, test) passes: 211/211 tests, 17/17 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)