### PR TITLE
[test] Make sync()-driving tests hermetic instead of hitting the live registry

### DIFF
--- a/tests/classes/Manager.test.ts
+++ b/tests/classes/Manager.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 import {
   PLUGIN,
   PLUGIN_INCOMPATIBLE,
@@ -7,6 +7,7 @@ import {
   PLUGIN_PACKAGE_INCOMPATIBLE,
   PLUGIN_PACKAGE_MULTIPLE,
 } from '../data/Plugin';
+import { REGISTRY_PLUGIN_VER } from '../data/Registry';
 import { Manager } from '../../src/classes/Manager';
 import { RegistryType } from '../../src/types/Registry';
 import { Package } from '../../src/classes/Package';
@@ -15,8 +16,12 @@ import { SystemType } from '../../src/types/SystemType';
 import { Architecture } from '../../src/types/Architecture';
 import { PackageVersion } from '../../src/types/Package';
 import { packageCompatibleFiles } from '../../src/helpers/package';
-import { omitDownloads } from '../testUtils';
+import { mockRegistrySync, omitDownloads } from '../testUtils';
 import * as apiHelpers from '../../src/helpers/api';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 test('Manager add multiple package versions', () => {
   const manager = new Manager(RegistryType.Plugins);
@@ -187,6 +192,7 @@ test('Manager search packages without versions', () => {
 });
 
 test('Manager sync from registries', async () => {
+  mockRegistrySync(REGISTRY_PLUGIN_VER);
   const manager = new Manager(RegistryType.Plugins);
   await manager.sync();
   const pkg = manager.getPackage(PLUGIN_PACKAGE.slug);
@@ -194,12 +200,18 @@ test('Manager sync from registries', async () => {
 });
 
 test('Manager sync skips an unreachable registry instead of throwing', async () => {
-  // example.invalid is reserved by RFC 2606 specifically for cases like this - guaranteed to
-  // never resolve, so this doesn't depend on some third-party service happening to be down.
+  // Simulate one registry that can't be reached (rather than depending on example.invalid's
+  // RFC 2606 guarantee to actually fail DNS resolution over a real network round trip) and one
+  // that responds normally, so this stays deterministic and network-free either way.
+  const apiJsonSpy = vi.spyOn(apiHelpers, 'apiJson').mockImplementation(async (url: string) => {
+    if (url.startsWith('https://example.invalid')) throw new Error('getaddrinfo ENOTFOUND example.invalid');
+    return REGISTRY_PLUGIN_VER;
+  });
+
   const manager = new Manager(RegistryType.Plugins, {
     registries: [
       { name: 'Unreachable Registry', url: 'https://example.invalid/registry' },
-      { name: 'Open Audio Registry', url: 'https://open-audio-stack.github.io/open-audio-stack-registry' },
+      { name: 'Reachable Registry', url: 'https://example.com/registry' },
     ],
   });
   await expect(manager.sync()).resolves.not.toThrow();
@@ -207,14 +219,16 @@ test('Manager sync skips an unreachable registry instead of throwing', async () 
 
   // The other, reachable registry should still have synced successfully.
   const pkg = manager.getPackage(PLUGIN_PACKAGE.slug);
-  expect(omitDownloads(pkg?.getVersion(PLUGIN_PACKAGE.version))).toEqual(omitDownloads(PLUGIN));
+  expect(pkg?.getVersion(PLUGIN_PACKAGE.version)).toEqual(PLUGIN);
+
+  apiJsonSpy.mockRestore();
 });
 
 test('Manager sync isolates a malformed package version instead of throwing', async () => {
   const pluginInvalid: PackageVersion = structuredClone(PLUGIN);
   delete (pluginInvalid as any).image;
 
-  const apiJsonSpy = vi.spyOn(apiHelpers, 'apiJson').mockResolvedValue({
+  vi.spyOn(apiHelpers, 'apiJson').mockResolvedValue({
     name: 'Mock Registry',
     url: 'https://example.invalid/mock',
     version: '1.0.0',
@@ -233,13 +247,11 @@ test('Manager sync isolates a malformed package version instead of throwing', as
   });
   await expect(manager.sync()).resolves.not.toThrow();
 
-  expect(omitDownloads(manager.getPackage('test-org/good-plugin')?.getVersion('1.0.0'))).toEqual(omitDownloads(PLUGIN));
+  expect(manager.getPackage('test-org/good-plugin')?.getVersion('1.0.0')).toEqual(PLUGIN);
   expect(manager.getPackage('test-org/bad-plugin')).toBeUndefined();
   expect(manager.getSyncErrors()).toEqual(
     expect.arrayContaining([expect.stringContaining('test-org/bad-plugin@1.0.0')]),
   );
-
-  apiJsonSpy.mockRestore();
 });
 
 test('Manager sync appends a configured registry version to the request url', async () => {
@@ -256,11 +268,10 @@ test('Manager sync appends a configured registry version to the request url', as
   await manager.sync();
 
   expect(apiJsonSpy).toHaveBeenCalledWith('https://example.invalid/registry/v1');
-
-  apiJsonSpy.mockRestore();
 });
 
 test('Manager sync with existing package', async () => {
+  mockRegistrySync(REGISTRY_PLUGIN_VER);
   const manager = new Manager(RegistryType.Plugins);
   const pkg = new Package(PLUGIN_PACKAGE.slug);
   pkg.addVersion(PLUGIN_PACKAGE.version, { ...PLUGIN, name: 'Surge modified' });

--- a/tests/classes/ManagerLocal.test.ts
+++ b/tests/classes/ManagerLocal.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { afterEach, beforeAll, expect, test, vi } from 'vitest';
 import { PLUGIN, PLUGIN_INSTALLED, PLUGIN_PACKAGE, PLUGIN_PACKAGE_INSTALLED } from '../data/Plugin';
 import { PRESET, PRESET_INSTALLED, PRESET_PACKAGE } from '../data/Preset';
 import {
@@ -10,6 +10,7 @@ import {
   PROJECT_NO_DEPS,
   PROJECT_PATH,
 } from '../data/Project';
+import { REGISTRY_PACKAGE_TYPES } from '../data/Registry';
 import { CONFIG_LOCAL_TEST } from '../data/Config';
 import { ManagerLocal } from '../../src/classes/ManagerLocal';
 import { Package } from '../../src/classes/Package';
@@ -29,7 +30,7 @@ import { ConfigInterface } from '../../src/types/Config';
 import { PackageVersion } from '../../src/types/Package';
 import { Architecture } from '../../src/types/Architecture';
 import { SystemType } from '../../src/types/SystemType';
-import { omitDownloads } from '../testUtils';
+import { mockRegistrySync, omitDownloads } from '../testUtils';
 
 const APP_DIR: string = 'test';
 // Explicitly test-scoped rather than relying on Config.test.ts/ConfigLocal.test.ts to have
@@ -37,6 +38,10 @@ const APP_DIR: string = 'test';
 // redirect pluginsDir/presetsDir/projectsDir, which otherwise default to real OS directories
 // (see configDefaultsLocal in src/helpers/configLocal.ts) regardless of cross-file test order.
 const CONFIG: ConfigInterface = CONFIG_LOCAL_TEST;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 beforeAll(() => {
   dirDelete(path.join(APP_DIR, 'archive'));
@@ -77,6 +82,7 @@ test('Scan reports a package with no metadata and no registry match as unsupport
 });
 
 test('Scan identifies a package with no metadata via a prior sync', async () => {
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
   await manager.sync();
   const dirTarget: string = path.join(
@@ -102,6 +108,7 @@ test('Scan identifies a package with no metadata via a prior sync', async () => 
 });
 
 test('Manager Local export', async () => {
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
   await manager.sync();
   manager.export(`test/export/${RegistryType.Plugins}`);
@@ -140,6 +147,7 @@ test('Desired architecture and system fall back to auto-detection for an unrecog
 test('Install throws when the desired architecture has no compatible files', async () => {
   // PLUGIN's files never target arm32 on any system, so forcing this architecture guarantees
   // zero compatible files regardless of which platform actually runs this test.
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Plugins, { ...CONFIG, architecture: Architecture.Arm32 });
   await manager.sync();
   await expect(manager.install(PLUGIN_PACKAGE.slug, PLUGIN_PACKAGE.version)).rejects.toThrow(
@@ -148,6 +156,7 @@ test('Install throws when the desired architecture has no compatible files', asy
 });
 
 test('Plugin sync, install, rescan, uninstall', async () => {
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
   await manager.sync();
 
@@ -165,6 +174,7 @@ test('Plugin sync, install, rescan, uninstall', async () => {
 });
 
 test('Preset sync, install, rescan, uninstall', async () => {
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Presets, CONFIG);
   await manager.sync();
 
@@ -182,6 +192,7 @@ test('Preset sync, install, rescan, uninstall', async () => {
 });
 
 test('Project sync, install, rescan, uninstall', async () => {
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Projects, CONFIG);
   await manager.sync();
 
@@ -205,6 +216,7 @@ test('Install archive package does not elevate when unprivileged', async () => {
   const isAdminSpy = vi.spyOn(fileHelpers, 'isAdmin').mockReturnValue(false);
   const isTestsSpy = vi.spyOn(utilsLocalHelpers, 'isTests').mockReturnValue(false);
   const runCliAsAdminSpy = vi.spyOn(fileHelpers, 'runCliAsAdmin').mockResolvedValue(undefined);
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
 
   const manager = new ManagerLocal(RegistryType.Projects, CONFIG);
   await manager.sync();
@@ -225,6 +237,7 @@ test('Install installer-only package still elevates when unprivileged', async ()
   const isAdminSpy = vi.spyOn(fileHelpers, 'isAdmin').mockReturnValue(false);
   const isTestsSpy = vi.spyOn(utilsLocalHelpers, 'isTests').mockReturnValue(false);
   const runCliAsAdminSpy = vi.spyOn(fileHelpers, 'runCliAsAdmin').mockResolvedValue(undefined);
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
 
   const manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
   await manager.sync();
@@ -268,6 +281,7 @@ test('Install all elevates when unprivileged', async () => {
 });
 
 test('Project sync, install project, install dependencies, uninstall dependencies', async () => {
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Projects, CONFIG);
   await manager.sync();
   await manager.install(PROJECT_PACKAGE.slug, PROJECT_PACKAGE.version);
@@ -288,6 +302,12 @@ test('Project sync, install project, install dependencies, uninstall dependencie
 });
 
 test('Project sync, install project, add new dependency, remove new dependency', async () => {
+  // Deliberately not mocked (unlike the other sync()-driving tests in this file): this test adds
+  // a dependency on surge-synthesizer/surge@1.3.4, a second real published version beyond the
+  // 1.3.1 covered by the static Plugin fixture/REGISTRY_PACKAGE_TYPES. installDependency() then
+  // downloads and sha256-verifies a real file for that version regardless of where the version
+  // metadata came from, so mocking just the registry JSON here wouldn't remove the live-network
+  // dependency, only relocate it - this stays a genuine end-to-end integration test.
   const manager = new ManagerLocal(RegistryType.Projects, CONFIG);
   await manager.sync();
   await manager.install(PROJECT_PACKAGE.slug, PROJECT_PACKAGE.version);
@@ -376,12 +396,14 @@ test('Open throws for a package not found in the registry', () => {
 });
 
 test('Open throws for a package version not found in the registry', async () => {
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Projects, CONFIG);
   await manager.sync();
   expect(() => manager.open(PROJECT_PACKAGE.slug, '99.99.99')).toThrow('version 99.99.99 not found');
 });
 
 test('Open throws for a package that is not installed', async () => {
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Projects, CONFIG);
   await manager.sync();
   // Earlier tests in this file install PROJECT_PACKAGE and don't always uninstall it
@@ -394,6 +416,7 @@ test('Open throws for a package that is not installed', async () => {
 });
 
 test('Open runs the compatible file and propagates errors instead of swallowing them', async () => {
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   const manager = new ManagerLocal(RegistryType.Projects, CONFIG);
   await manager.sync();
   await manager.install(PROJECT_PACKAGE.slug, PROJECT_PACKAGE.version);

--- a/tests/classes/Registry.test.ts
+++ b/tests/classes/Registry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { Registry } from '../../src/classes/Registry.js';
 import { RegistryType } from '../../src/types/Registry.js';
 import {
@@ -14,6 +14,7 @@ import { PRESET, PRESET_PACKAGE } from '../data/Preset.js';
 import { PROJECT, PROJECT_PACKAGE } from '../data/Project.js';
 import { Manager } from '../../src/classes/Manager.js';
 import { Package } from '../../src/classes/Package.js';
+import { mockRegistrySync } from '../testUtils.js';
 
 let registry: Registry;
 let manager: Manager;
@@ -22,6 +23,10 @@ beforeEach(() => {
   registry = new Registry(REGISTRY.name, REGISTRY.url, REGISTRY.version);
   manager = new Manager(RegistryType.Plugins);
   registry.addManager(manager);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 test('Create new Registry', () => {
@@ -137,9 +142,14 @@ test('Sync managers', async () => {
   const pkgProject = new Package(PROJECT_PACKAGE.slug);
   pkgProject.addVersion(PROJECT_PACKAGE.version, PROJECT);
   projectManager.addPackage(pkgProject);
-  // Sync managers
+  // Sync managers - one mocked response covers all three managers, since each only reads its
+  // own key (plugins/presets/projects) out of the combined payload.
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   await registry.sync();
-  expect(registry.toJSON()).toBeDefined();
+  // The synced data is identical to what was already added above, so the merged result should
+  // be unchanged - this is a stronger assertion than the previous `toBeDefined()`, which passed
+  // regardless of what sync() actually did.
+  expect(registry.toJSON()).toEqual(REGISTRY_PACKAGE_TYPES);
 });
 
 test('Get registry name', () => {

--- a/tests/classes/RegistryLocal.test.ts
+++ b/tests/classes/RegistryLocal.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { RegistryLocal } from '../../src/classes/RegistryLocal.js';
 import { RegistryType } from '../../src/types/Registry.js';
 import {
@@ -16,6 +16,7 @@ import { ManagerLocal } from '../../src/classes/ManagerLocal.js';
 import { Package } from '../../src/classes/Package.js';
 import { ConfigInterface } from '../../src/types/Config.js';
 import { fileReadJson } from '../../src/helpers/file.js';
+import { mockRegistrySync } from '../testUtils.js';
 
 const APP_DIR: string = 'test';
 const CONFIG: ConfigInterface = {
@@ -29,6 +30,10 @@ beforeEach(() => {
   registry = new RegistryLocal(REGISTRY.name, REGISTRY.url, REGISTRY.version);
   manager = new ManagerLocal(RegistryType.Plugins, CONFIG);
   registry.addManager(manager);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 test('Create new Registry', () => {
@@ -144,9 +149,14 @@ test('Sync managers', async () => {
   const pkgProject = new Package(PROJECT_PACKAGE.slug);
   pkgProject.addVersion(PROJECT_PACKAGE.version, PROJECT);
   projectManager.addPackage(pkgProject);
-  // Sync managers
+  // Sync managers - one mocked response covers all three managers, since each only reads its
+  // own key (plugins/presets/projects) out of the combined payload.
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   await registry.sync();
-  expect(registry.toJSON()).toBeDefined();
+  // The synced data is identical to what was already added above, so the merged result should
+  // be unchanged - this is a stronger assertion than the previous `toBeDefined()`, which passed
+  // regardless of what sync() actually did.
+  expect(registry.toJSON()).toEqual(REGISTRY_PACKAGE_TYPES);
 });
 
 test('Registry scan', async () => {
@@ -176,6 +186,7 @@ test('Registry export', async () => {
   registry.addManager(presetManager);
   const projectManager = new ManagerLocal(RegistryType.Projects, CONFIG);
   registry.addManager(projectManager);
+  mockRegistrySync(REGISTRY_PACKAGE_TYPES);
   await registry.sync();
   registry.export(`test/export`);
   const report = fileReadJson('test/export/plugins/report.json');

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -1,3 +1,7 @@
+import { vi } from 'vitest';
+import * as apiHelpers from '../src/helpers/api.js';
+import { RegistryInterface } from '../src/types/Registry.js';
+
 // Deep-clones `value`, dropping any key in `keys` at any depth. Used to compare fixtures against
 // real results while excluding fields that are inherently non-reproducible - see `omitDownloads`.
 export function omitKeysDeep<T>(value: T, keys: string[]): T {
@@ -15,11 +19,29 @@ export function omitKeysDeep<T>(value: T, keys: string[]): T {
 
 // `downloads` is computed fresh at build time from live GitHub release download counts (see
 // registry's enrichDownloads()) - unlike every other field on these fixtures (hash, size, date),
-// it changes continuously in the real, live registry these tests sync against, and is only ever
-// set when > 0 (omitted otherwise). Because it can be entirely absent, an asymmetric matcher like
-// `expect.any(Number)` can't stand in for it - vitest's toEqual still requires the key to exist on
-// both sides before consulting a matcher. So exclude it from both the actual result and the
-// expected fixture before comparing, rather than asserting a point-in-time snapshot of it.
+// it would change continuously against a live registry, and is only ever set when > 0 (omitted
+// otherwise). Because it can be entirely absent, an asymmetric matcher like `expect.any(Number)`
+// can't stand in for it - vitest's toEqual still requires the key to exist on both sides before
+// consulting a matcher. So exclude it from both the actual result and the expected fixture before
+// comparing, rather than asserting a point-in-time snapshot of it. Most sync()-driving tests now
+// use mockRegistrySync() below instead of the live registry, so this is largely defensive at this
+// point, but still applies to the handful of tests that intentionally still sync against the real
+// registry (see their own comments) and to any future fixture that does carry a `downloads` field.
 export function omitDownloads<T>(value: T): T {
   return omitKeysDeep(value, ['downloads']);
+}
+
+// Stubs sync()'s registry fetch (apiJson) to resolve with a fixed local payload instead of making
+// a live network call - keeps tests deterministic and fast regardless of the real registry's
+// current content or uptime (previously almost every sync()-driving test synced against the real,
+// live registry - see the "hermetic tests" item in review.md). Caller must restore the mock once
+// done, e.g. via `afterEach(() => vi.restoreAllMocks())`.
+//
+// structuredClone()s the payload on every call rather than resolving the same object reference -
+// PackageVersion objects get mutated in place downstream (e.g. ManagerLocal.install()/uninstall()
+// set/delete `installed` directly on the object stored in Package.versions), so a real apiJson()
+// response - a fresh object graph from JSON.parse every time - never leaks a mutation from one
+// sync() call into another the way resolving one shared fixture object repeatedly would.
+export function mockRegistrySync(registry: RegistryInterface) {
+  return vi.spyOn(apiHelpers, 'apiJson').mockImplementation(async () => structuredClone(registry));
 }


### PR DESCRIPTION
## Summary
- Nearly every `sync()`-driving test across `Manager.test.ts`, `ManagerLocal.test.ts`, `Registry.test.ts`, and `RegistryLocal.test.ts` synced against the real, live `open-audio-stack-registry` GitHub Pages site over the network. CI correctness was coupled to that site's uptime and current content - a transient outage or a content change unrelated to any code change could fail the suite, and it couldn't distinguish "my change broke this" from "the registry changed".
- Adds `mockRegistrySync()` to `tests/testUtils.ts`, which stubs `apiJson` (the function `sync()` calls to fetch a registry) to resolve with a fixed local fixture instead. Applied to every `sync()` call across the four affected test files that only needs the existing single-version `PLUGIN`/`PRESET`/`PROJECT` fixtures.
- Found and fixed a real bug in my first pass at the mock: `mockResolvedValue(fixture)` resolves the *same* object reference on every call, but `ManagerLocal.install()`/`uninstall()` mutate the `PackageVersion` object in place (`pkgVersion.installed = true` / `delete pkgVersion.installed`) rather than cloning it - a real network response is a fresh object graph from `JSON.parse` every time, so this never surfaced before. `mockRegistrySync()` now `structuredClone()`s the payload per call to match that real behavior, otherwise mutation state leaked between unrelated tests sharing the same imported fixture object.
- One test (`Project sync, install project, add new dependency, remove new dependency`) is deliberately left hitting the live registry, with a comment explaining why: it adds a dependency on `surge-synthesizer/surge@1.3.4`, a second real published version beyond what the static fixtures cover, and `installDependency()` then downloads and sha256-verifies a real file for that version regardless of where the version JSON came from - mocking just the registry response there wouldn't remove the live-network dependency, only relocate it. It stays a genuine end-to-end integration test.
- `Registry.test.ts`/`RegistryLocal.test.ts`'s "Sync managers" tests previously only asserted `toBeDefined()` (passed regardless of what `sync()` actually did) - now that the data is deterministic, strengthened to `toEqual(REGISTRY_PACKAGE_TYPES)`.
- No `specification.md` changes - this is test infrastructure only, no observable behavior changed.

This is item 2 of the architectural review in `review.md` (Critical Blocker #3), and was sequenced before the `ManagerLocal.install()` transactional-rollback fix (item 3, next) specifically so that fix's tests can be trusted.

## Test plan
- [x] `npm run check` (format, lint, build, test): 207/207 tests, 17/17 files pass.
- [x] Verified the mock-cloning fix by reproducing the failure first: without `structuredClone()`, 3 tests failed with stray `installed: true` leaking from an earlier test's mutation of the shared fixture object.
- [x] Confirmed every `manager.sync()`/`registry.sync()` call site across the four files is now either mocked or has an explicit comment explaining why it's intentionally still live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)